### PR TITLE
[Hotfix] #24 - 파트너찾기 NI 오류 해결

### DIFF
--- a/BurningBuddy.xcodeproj/project.pbxproj
+++ b/BurningBuddy.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BurningBuddy\"";
-				DEVELOPMENT_TEAM = 82Q43H4UQQ;
+				DEVELOPMENT_TEAM = GZMCL5Q7N2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BurningBuddy/Info.plist;
@@ -551,7 +551,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.west.BurningBuddy;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hon.BurningBuddy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -567,7 +567,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BurningBuddy\"";
-				DEVELOPMENT_TEAM = 82Q43H4UQQ;
+				DEVELOPMENT_TEAM = GZMCL5Q7N2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BurningBuddy/Info.plist;
@@ -587,7 +587,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.west.BurningBuddy;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hon.BurningBuddy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/BurningBuddy/Info.plist
+++ b/BurningBuddy/Info.plist
@@ -13,8 +13,8 @@
 	</array>
 	<key>NSBonjourServices</key>
 	<array>
-		<string>_nearcatch._tcp</string>
-		<string>_nearcatch._udp</string>
+		<string>_burningbuddy._tcp</string>
+		<string>_burningbuddy._udp</string>
 	</array>
 </dict>
 </plist>

--- a/BurningBuddy/Model/WorkoutData.swift
+++ b/BurningBuddy/Model/WorkoutData.swift
@@ -46,7 +46,7 @@ class WorkoutData: ObservableObject{
         // 파트너와 태그한 이후부터 운동종료 버튼을 누른 순간까지의 운동 기록을 불러오기 위함
         let predicate = HKQuery.predicateForSamples(withStart: workoutStartTime, end: now, options: .strictStartDate)
         
-        let query = HKAnchoredObjectQuery(type: type, predicate: predicate, anchor: nil, limit: HKObjectQueryNoLimit) { (quㄴery, samples, deletedObjects, anchor, error) in
+        let query = HKAnchoredObjectQuery(type: type, predicate: predicate, anchor: nil, limit: HKObjectQueryNoLimit) { (query, samples, deletedObjects, anchor, error) in
             
             if let samples = samples as? [HKWorkout], !samples.isEmpty {
                 var totalTime: TimeInterval = 0.0

--- a/BurningBuddy/Utils/NIUtils/MPCUtils/MPCSession.swift
+++ b/BurningBuddy/Utils/NIUtils/MPCUtils/MPCSession.swift
@@ -1,13 +1,16 @@
-//
-//  MPCSession.swift
-//  BurningBuddy
-//
-//  Created by 박의서 on 2023/05/08.
-//
+/*
+See LICENSE folder for this sample’s licensing information.
+
+Abstract:
+A class that manages peer discovery-token exchange over the local network by using MultipeerConnectivity.
+*/
 
 import Foundation
 import MultipeerConnectivity
 
+// MultipeerConnectivity 프레임워크를 사용하여 로컬 네트워크에서 피어 디스커버리 및 데이터 교환을 관리하는 MPCSession 클래스를 정의하는 코드
+
+// 상수를 정의하는 구조체
 struct MPCSessionConstants {
     static let kKeyIdentity: String = "identity"
 }
@@ -16,19 +19,23 @@ protocol MultipeerConnectivityManagerDelegate: AnyObject {
     func connectedDevicesChanged(devices: [String])
 }
 
+// MCSessionDelegate, MCNearbyServiceBrowserDelegate, MCNearbyServiceAdvertiserDelegate 프로토콜을 채택하여 MultipeerConnectivity 프레임워크의 세 가지 주요 구성요소에 대한 이벤트를 처리
 class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, MCNearbyServiceAdvertiserDelegate {
-    var peerDataHandler: ((Data, MCPeerID) -> Void)?
-    var peerConnectedHandler: ((MCPeerID) -> Void)?
-    var peerDisconnectedHandler: ((MCPeerID) -> Void)?
+    // Handler: 이벤트 핸들러, 외부에서 설정 가능, MPCSession인스턴스에서 이벤트가 발생할 때 실행
+    var peerDataHandler: ((Data, MCPeerID) -> Void)? // 연결된 피어에서 데이터를 수신하면 호출
+    var peerConnectedHandler: ((MCPeerID) -> Void)? // 피어가 연결되면 호출
+    var peerDisconnectedHandler: ((MCPeerID) -> Void)? // 피어가 연결 해체되면 호출
+    
     private let serviceString: String
     private let mcSession: MCSession
-    private let localPeerID = MCPeerID(displayName: UIDevice.current.name)
-    private let mcAdvertiser: MCNearbyServiceAdvertiser
+    private let localPeerID = MCPeerID(displayName: UIDevice.current.name) // 로컬 피어 아이디 생성
+    private let mcAdvertiser: MCNearbyServiceAdvertiser // 초대에 대해 알림
     private let mcBrowser: MCNearbyServiceBrowser
     private let identityString: String
+    private let maxNumPeers: Int // 최대 연결 가능한 피어 수
     weak var delegate: MultipeerConnectivityManagerDelegate?
 
-    init(service: String, identity: String) {
+    init(service: String, identity: String, maxPeers: Int) {
         serviceString = service
         identityString = identity
         mcSession = MCSession(peer: localPeerID, securityIdentity: nil, encryptionPreference: .required)
@@ -36,6 +43,7 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
                                                  discoveryInfo: [MPCSessionConstants.kKeyIdentity: identityString],
                                                  serviceType: serviceString)
         mcBrowser = MCNearbyServiceBrowser(peer: localPeerID, serviceType: serviceString)
+        maxNumPeers = maxPeers
 
         super.init()
         mcSession.delegate = self
@@ -43,20 +51,18 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         mcBrowser.delegate = self
     }
 
+    
+    
     // MARK: - `MPCSession` public methods.
+    // Begins advertising the service provided by a local peer and starts the assistant. - 서비스를 advertising하기 시작하고, assistant시작
     func start() {
-        NSLog("Start advertising")
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.mcAdvertiser.startAdvertisingPeer()
-            self.mcBrowser.startBrowsingForPeers()
-        }
+        mcAdvertiser.startAdvertisingPeer()
+        mcBrowser.startBrowsingForPeers()
     }
 
     func suspend() {
-        DispatchQueue.global(qos: .userInitiated).async {
-            self.mcAdvertiser.stopAdvertisingPeer()
-            self.mcBrowser.stopBrowsingForPeers()
-        }
+        mcAdvertiser.stopAdvertisingPeer()
+        mcBrowser.stopBrowsingForPeers()
     }
 
     func invalidate() {
@@ -76,12 +82,19 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         }
     }
 
+    
+    
     // MARK: - `MPCSession` private methods.
     private func peerConnected(peerID: MCPeerID) {
         if let handler = peerConnectedHandler {
             DispatchQueue.main.async {
                 handler(peerID)
             }
+        }
+        
+        // 연결 가능한 최대 피어 수를 초과하면 연결 요청 거부
+        if mcSession.connectedPeers.count == maxNumPeers {
+            self.suspend()
         }
     }
 
@@ -91,9 +104,19 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
                 handler(peerID)
             }
         }
+        
+        // 연결 가능한 최대 피어수보다 작으면 start
+        if mcSession.connectedPeers.count < maxNumPeers {
+            self.start()
+        }
     }
 
-    // MARK: - `MCSessionDelegate`.
+    
+    // MARK: - Protocol: `MCSessionDelegate`. - 6개, 세션 관련 이벤트를 처리
+    // The MCSessionDelegate protocol defines methods that a delegate of the MCSession class can implement to handle session-related events. For more information, see MCSession. - 세션 관련 이벤트를 처리하기 위해 구현할 수 있는 방법을 정의
+    // Delegate calls occur on a private serial queue. If your app needs to perform an action on a particular run loop or operation queue, its delegate method should explicitly dispatch or schedule that work.
+    
+    // Called when the state of a nearby peer changes. - nearby peer의 상태가 바꼈을때 호출
     internal func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         switch state {
         case .connected:
@@ -103,14 +126,11 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         case .connecting:
             break
         @unknown default:
-            //            fatalError("Unhandled MCSessionState")
-            return
-        }
-        DispatchQueue.main.async {
-            self.delegate?.connectedDevicesChanged(devices: session.connectedPeers.map{$0.displayName})
+            fatalError("Unhandled MCSessionState")
         }
     }
 
+    // Indicates that an NSData object has been received from a nearby peer. - nearby peer로 부터 NSData object를 받았을때
     internal func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         if let handler = peerDataHandler {
             DispatchQueue.main.async {
@@ -119,44 +139,64 @@ class MPCSession: NSObject, MCSessionDelegate, MCNearbyServiceBrowserDelegate, M
         }
     }
 
+    // Called when a nearby peer opens a byte stream connection to the local peer. - nearby peer가 local peer에 대한 바이트 스트림 연결을 열 때 호출됩니다.
     internal func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
-        // The sample app intentionally omits this implementation.
+        // The sample app intentional omits this implementation. - 샘플 앱은 implement를 의도적으로 생략했음
     }
 
-    internal func session(_ session: MCSession,
-                          didStartReceivingResourceWithName resourceName: String,
-                          fromPeer peerID: MCPeerID,
+    // Indicates that the local peer began receiving a resource from a nearby peer. - local peer가 nearby peer에게 리소스를 받기 시작했을때
+    internal func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID,
                           with progress: Progress) {
-        // The sample app intentionally omits this implementation.
+        // progress: An NSProgress object that can be used to cancel the transfer or queried to determine how far the transfer has progressed. - 전송을 취소하는 데 사용하거나 전송이 얼마나 진행되었는지 확인하기 위해 쿼리할 수 있는 NSProgress 개체
+        
+        // The sample app intentional omits this implementation. - 샘플 앱은 implement를 의도적으로 생략했음
     }
 
-    internal func session(_ session: MCSession,
-                          didFinishReceivingResourceWithName resourceName: String,
+    // Indicates that the local peer finished receiving a resource from a nearby peer. - local peer가 nearby peer로 부터 리소스를 받는 것을 끝냈다는 것을 가르킴
+    internal func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String,
                           fromPeer peerID: MCPeerID,
                           at localURL: URL?,
                           withError error: Error?) {
-        // The sample app intentionally omits this implementation.
+        // localURL: An NSURL object that provides the location of a temporary file containing the received data. - 수신된 데이터가 포함된 임시 파일의 위치를 제공하는 NSURL 개체
+        // withError: An error object indicating what went wrong if the file was not received successfully, or nil. - 파일을 성공적으로 수신하지 못한 경우 무엇이 잘못되었는지 나타내는 오류 개체 또는 0
+        
+        // The sample app intentional omits this implementation. - 샘플 앱은 implement를 의도적으로 생략했음
     }
 
-    // MARK: - `MCNearbyServiceBrowserDelegate`.
+    
+    
+    // MARK: - Protocol: `MCNearbyServiceBrowserDelegate`. - Error Handling Delegate Methods, Peer Discovery Delegate Methods
+    // The MCNearbyServiceBrowserDelegate protocol defines methods that a MCNearbyServiceBrowser object’s delegate can implement to handle browser-related events. - MCNearbyServiceBrowser 개체의 대리자가 브라우저 관련 이벤트를 처리하기 위해 구현할 수 있는 메서드를 정의
+    
+    // Called when a nearby peer is found. - nearby peer를 찾았을때
     internal func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         guard let identityValue = info?[MPCSessionConstants.kKeyIdentity] else {
             return
         }
-        if identityValue == identityString {
+        if identityValue == identityString && mcSession.connectedPeers.count < maxNumPeers {
             browser.invitePeer(peerID, to: mcSession, withContext: nil, timeout: 10)
         }
     }
 
+    // Called when a nearby peer is found. - nearby peer를 잃었을때
     internal func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        // The sample app intentionally omits this implementation.
+        // The sample app intentional omits this implementation. - 샘플 앱은 implement를 의도적으로 생략했음
     }
 
-    // MARK: - `MCNearbyServiceAdvertiserDelegate`.
+    
+    
+    // MARK: - Protocol: `MCNearbyServiceAdvertiserDelegate`. - Error Handling Methods, Invitation Handling Delegate Methods
+    // The MCNearbyServiceAdvertiserDelegate protocol describes the methods that the delegate object for an MCNearbyServiceAdvertiser instance can implement for handling events from the MCNearbyServiceAdvertiser class. - MCNearbyServiceAdvertiser 인스턴스에 대한 위임 개체가 MCNearbyServiceAdvertiser 클래스의 이벤트를 처리하기 위해 구현할 수 있는 방법을 설명합니다.
+    
+    // Called when an invitation to join a session is received from a nearby peer. - nearby peer로부터 session 초대를 받으면 호출됨
     internal func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
                              didReceiveInvitationFromPeer peerID: MCPeerID,
                              withContext context: Data?,
                              invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        invitationHandler(true, mcSession)
+        // Accept the invitation only if the number of peers is less than the maximum.
+        if self.mcSession.connectedPeers.count < maxNumPeers {
+            invitationHandler(true, mcSession)
+        }
     }
+    
 }

--- a/BurningBuddy/Utils/NIUtils/MPCUtils/MPCSession.swift
+++ b/BurningBuddy/Utils/NIUtils/MPCUtils/MPCSession.swift
@@ -1,9 +1,10 @@
-/*
-See LICENSE folder for this sample’s licensing information.
-
-Abstract:
-A class that manages peer discovery-token exchange over the local network by using MultipeerConnectivity.
-*/
+//
+//  MPCSession.swift
+//  BurningBuddy
+//
+//  Created by 박의서 on 2023/05/08.
+//
+// inspired by https://developer.apple.com/documentation/nearbyinteraction/implementing_interactions_between_users_in_close_proximity
 
 import Foundation
 import MultipeerConnectivity


### PR DESCRIPTION
MPCSession 코드를 Apple Sample 코드로 변경
파트너찾기 뷰에서 상태가 초기화되지 않는 문제 해결

## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- Hotfix/#24

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
파트너 찾기 뷰에서 파트너를 최초로 찾은 다음, 2번쨰부터는 등록된 파트너만 찾아지는 오류 해결

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
[Apple의 Tutorial Code](https://developer.apple.com/documentation/nearbyinteraction/implementing_interactions_between_users_in_close_proximity)를 참고했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-BurningBuddy/assets/97583162/d886e4b4-2c65-48a1-881b-2a6cfd8de4f1" width ="250">|


## 📟 관련 이슈
- Resolved: #24 
