### PR TITLE
Feature/#35

### DIFF
--- a/BurningBuddy.xcodeproj/project.pbxproj
+++ b/BurningBuddy.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		C9CB702F2A0B6CCD0031A91B /* Onboarding3.png in Resources */ = {isa = PBXBuildFile; fileRef = C9CB702C2A0B6CCD0031A91B /* Onboarding3.png */; };
 		C9CB70302A0B6CCD0031A91B /* Onboarding2.png in Resources */ = {isa = PBXBuildFile; fileRef = C9CB702D2A0B6CCD0031A91B /* Onboarding2.png */; };
 		C9CC8F382A0232D400C16FA5 /* Image.png in Resources */ = {isa = PBXBuildFile; fileRef = C9CC8F372A0232D400C16FA5 /* Image.png */; };
+		C9F9E2652A0D0DA7007EFF1E /* LoadingAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F9E2642A0D0DA7007EFF1E /* LoadingAnimationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +91,7 @@
 		C9CB702C2A0B6CCD0031A91B /* Onboarding3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Onboarding3.png; sourceTree = "<group>"; };
 		C9CB702D2A0B6CCD0031A91B /* Onboarding2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Onboarding2.png; sourceTree = "<group>"; };
 		C9CC8F372A0232D400C16FA5 /* Image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Image.png; sourceTree = "<group>"; };
+		C9F9E2642A0D0DA7007EFF1E /* LoadingAnimationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingAnimationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -249,6 +251,7 @@
 			isa = PBXGroup;
 			children = (
 				C91444052A01453800E6202D /* SearchPartnerView.swift */,
+				C9F9E2642A0D0DA7007EFF1E /* LoadingAnimationView.swift */,
 				C967C2172A07870A007EE7EE /* NotFoundPartnerView.swift */,
 			);
 			path = Partner;
@@ -384,6 +387,7 @@
 				C91BB6FE2A00E794009FAA86 /* NicknameSettingView.swift in Sources */,
 				C967C2082A0332C3007EE7EE /* WorkoutDoneView.swift in Sources */,
 				C967C21C2A078754007EE7EE /* MissionResultModalView.swift in Sources */,
+				C9F9E2652A0D0DA7007EFF1E /* LoadingAnimationView.swift in Sources */,
 				C91444062A01453800E6202D /* SearchPartnerView.swift in Sources */,
 				3E6C34D82A08C8D100F1CBFF /* Bunny+CoreDataProperties.swift in Sources */,
 				B80518E52A088CDE00D12915 /* MPCSession.swift in Sources */,

--- a/BurningBuddy/BurningBuddyApp.swift
+++ b/BurningBuddy/BurningBuddyApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+
 @main
 struct BurningBuddyApp: App {
     var body: some Scene {

--- a/BurningBuddy/View/Main/MainView.swift
+++ b/BurningBuddy/View/Main/MainView.swift
@@ -177,7 +177,10 @@ struct MainView: View {
             }
             .padding(EdgeInsets(top: 20, leading: 30, bottom: 15, trailing: 30))
             .background(Color.backgroundColor)
-        }
+            .navigationBarTitle("")
+            
+        }.accentColor(Color.mainTextColor)
+        
     } // body End
 }
 

--- a/BurningBuddy/View/Partner/NotFoundPartnerView.swift
+++ b/BurningBuddy/View/Partner/NotFoundPartnerView.swift
@@ -25,7 +25,7 @@ struct NotFoundPartnerView: View {
             Image(systemName: "person.crop.circle.fill")
                 .resizable()
                 .frame(width: 93, height: 91)
-                .foregroundColor(Color(red: 255 / 255, green: 0 / 255, blue: 82 / 255))
+                .foregroundColor(Color.bunnyColor)
             Spacer()
             
             // 모달 뷰의 텍스트
@@ -44,6 +44,8 @@ struct NotFoundPartnerView: View {
             .buttonStyle(RedButtonStyle())
         }
         .padding(EdgeInsets(top: 20, leading: 30, bottom: 15, trailing: 30))
+        
+        
     }
 }
 

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -15,9 +15,11 @@ import SwiftUI
  */
 struct SearchPartnerView: View {
     @EnvironmentObject var settings: UserSettings
+    @Environment(\.presentationMode) var presentationMode
     @State var isSearchedPartner: Bool = false // 화면 전환용
     @State var notFoundPartner: Bool = false // 모달용
     @State var partnerData: String = "상대방 닉네임" // TODO: - 데이터 타입 지정 필요
+    
     @State private var beforeStart: Bool = false
     //  @EnvironmentObject var niObject: NISessionManager
     @StateObject var niObject = NISessionManager()
@@ -25,6 +27,7 @@ struct SearchPartnerView: View {
     @State var isLocalNetworkPermissionDenied = false
     @State private var startWorkout: Bool = false
     @State private var tag:Int? = nil
+    @State var isNextButtonTapped = false
     
     let localNetAuth = LocalNetworkAuthorization() // MPC를 위한 객체생성
     
@@ -111,37 +114,27 @@ struct SearchPartnerView: View {
             case true:
                 HStack {
                     Button("다시 연결할래요", action: {
-                        
+                        niObject.isBumped = false
+                        niObject.findingPartnerState = .finding
                     })
                     .buttonStyle(GrayButtonStyle())
                     
-                    NavigationLink(destination: WorkoutView(), tag: 1, selection: self.$tag) {
-                        Text("연결하기")
-                    }
-                    .buttonStyle(RedButtonStyle())
-                    Button(action: {
-                        self.tag = 1
-                    }) {
-                        EmptyView()
-                    }
+                    NavigationLink(isActive: $isNextButtonTapped, destination: {
+                        WorkoutView()
+                    }, label: {
+                        Button("연결하기") {
+                            self.beforeStart = true
+                            self.isNextButtonTapped = true
+                        }.buttonStyle(RedButtonStyle())
+                    })
+//
+//                    NavigationLink(destination: WorkoutView(), tag: 0, selection: self.$tag) {
+//                        Text("연결하기")
+//                    }
+//                    .buttonStyle(RedButtonStyle())
                     
-                    /**
-                     NavigationLink(destination: {
-                     WorkoutView()
-                     .environmentObject(settings)
-                     }, label: {Text("연결하기")}) {
-                     
-                     }
-                     .alert(isPresented: $beforeStart, content: {
-                     Alert(title: Text("애플워치를 착용하고 있나요?"), message: Text("애플워치를 착용한 후 피트니스 앱의 운동 시작하기를 눌러주세요. 운동량 측정을 통해 캐릭터를 성장시킬 수 있습니다."), primaryButton: .cancel(Text("뒤로가기")), secondaryButton: .default(Text("착용했어요"), action: { // 운동 시작하기
-                     startWorkout.toggle()
-                     }))
-                     })
-                     .buttonStyle(RedButtonStyle())
-                     */
+                    
                 }
-                
-                
             case false:
                 Text("")
             }
@@ -159,11 +152,38 @@ struct SearchPartnerView: View {
                     .background(Color.backgroundColor)
             }
         }
+//        .alert(isPresented: $beforeStart, content: {
+//            Alert(title: Text("애플워치를 착용하고 있나요?"), message: Text("애플워치를 착용한 후 피트니스 앱의 운동 시작하기를 눌러주세요. 운동량 측정을 통해 캐릭터를 성장시킬 수 있습니다."), primaryButton: .cancel(Text("뒤로가기")), secondaryButton: .default(Text("착용했어요")))
+//            }
+//        })
         
-    } // body End
-    
-}
+//        .alert("애플워치를 착용하고 있나요?", isPresented: $beforeStart) {
+//          Button("OK", role: .destructive) {
+//              beforeStart = false
+//              self.tag = 1
+//              print("tap ok") }
+//          Button("cancel", role: .cancel) {
+//              presentationMode.wrappedValue.dismiss()
+//              print("tap cancel") }
+//        }
+        
+        
+        .alert(isPresented:$beforeStart) {
+            Alert(
+                title: Text("애플워치를 착용하고 있나요?"),
+                message: Text("애플워치를 착용한 후 피트니스 앱의 운동 시작하기를 눌러주세요. 운동량 측정을 통해 캐릭터를 성장시킬 수 있습니다."),
+                primaryButton: .destructive(Text("뒤로가기")) {
+                    print("tap cancel")
+                },
+                secondaryButton: .cancel(Text("착용했어요")) {
+                    self.beforeStart = false
+                    self.isNextButtonTapped = true
+                }
+            )
+        }
+    } //
 
+}
 
 
 

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -124,7 +124,7 @@ struct SearchPartnerView: View {
                     }, label: {
                         Button("연결하기") {
                             self.beforeStart = true
-                            self.isNextButtonTapped = true
+//                            self.isNextButtonTapped = true
                         }.buttonStyle(RedButtonStyle())
                     })
 //
@@ -181,7 +181,8 @@ struct SearchPartnerView: View {
                 }
             )
         }
-    } //
+        
+    } // end body
 
 }
 

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -21,7 +21,6 @@ struct SearchPartnerView: View {
     @State var partnerData: String = "상대방 닉네임" // TODO: - 데이터 타입 지정 필요
     
     @State private var beforeStart: Bool = false
-    //  @EnvironmentObject var niObject: NISessionManager
     @StateObject var niObject = NISessionManager()
     @State var isLaunched = true
     @State var isLocalNetworkPermissionDenied = false
@@ -67,44 +66,32 @@ struct SearchPartnerView: View {
                     .foregroundColor(Color.mainTextColor)
                     .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
             }
-//            ZStack {
-                //                Circle()
-                //                    .foregroundColor(Color(red: 44/255, green: 44/255, blue: 46/255))
-                //                    .padding(EdgeInsets(top: -70, leading: -70, bottom: -70, trailing: -70))
-                //                Circle()
-                //                    .foregroundColor(Color(red: 74/255, green: 74/255, blue: 77/255))
-                //                    .padding(EdgeInsets(top: -8, leading: -8, bottom: -8, trailing: -8))
-//                Circle()
-//                    .foregroundColor(Color(red: 124/255, green: 124/255, blue:129/255, opacity: 0.8))
-//                    .padding(EdgeInsets(top: 54, leading: 54, bottom: 54, trailing: 54))
-                
-                    switch(niObject.isBumped) {
-                    case true:
-                        ZStack{
-                            Circle()
-                                .scale(1.5)
-                                .opacity(0.3)
-                                .foregroundColor(Color("iconColor"))
-                            Circle()
-                                .scale(1.0)
-                                .opacity(0.6)
-                                .foregroundColor(Color("iconColor"))
-                            Circle()
-                                .scale(0.5)
-                                .opacity(0.9)
-                                .foregroundColor(Color("iconColor"))
-                            VStack{
-                                Image("Image")
-                                Text(niObject.bumpedName)
-                            }
-                        }
-                        
-                    case false:
-                        LoadingAnimationView()
+            
+            
+            switch(niObject.isBumped) {
+            case true:
+                ZStack{
+                    Circle()
+                        .scale(1.5)
+                        .opacity(0.3)
+                        .foregroundColor(Color("iconColor"))
+                    Circle()
+                        .scale(1.0)
+                        .opacity(0.6)
+                        .foregroundColor(Color("iconColor"))
+                    Circle()
+                        .scale(0.5)
+                        .opacity(0.9)
+                        .foregroundColor(Color("iconColor"))
+                    VStack{
+                        Image("Image")
+                        Text(niObject.bumpedName)
                     }
+                }
                 
-//                .padding(EdgeInsets(top: 106, leading: 106, bottom: 106, trailing: 106))
-//            }
+            case false:
+                LoadingAnimationView()
+            }
             Spacer()
             switch(niObject.isBumped) {
             case true:
@@ -120,16 +107,9 @@ struct SearchPartnerView: View {
                     }, label: {
                         Button("연결하기") {
                             self.beforeStart = true
-//                            self.isNextButtonTapped = true
+                            //                            self.isNextButtonTapped = true
                         }.buttonStyle(RedButtonStyle())
                     })
-//
-//                    NavigationLink(destination: WorkoutView(), tag: 0, selection: self.$tag) {
-//                        Text("연결하기")
-//                    }
-//                    .buttonStyle(RedButtonStyle())
-                    
-                    
                 }
             case false:
                 Text("")
@@ -168,22 +148,6 @@ struct SearchPartnerView: View {
                     .background(Color.backgroundColor)
             }
         }
-//        .alert(isPresented: $beforeStart, content: {
-//            Alert(title: Text("애플워치를 착용하고 있나요?"), message: Text("애플워치를 착용한 후 피트니스 앱의 운동 시작하기를 눌러주세요. 운동량 측정을 통해 캐릭터를 성장시킬 수 있습니다."), primaryButton: .cancel(Text("뒤로가기")), secondaryButton: .default(Text("착용했어요")))
-//            }
-//        })
-        
-//        .alert("애플워치를 착용하고 있나요?", isPresented: $beforeStart) {
-//          Button("OK", role: .destructive) {
-//              beforeStart = false
-//              self.tag = 1
-//              print("tap ok") }
-//          Button("cancel", role: .cancel) {
-//              presentationMode.wrappedValue.dismiss()
-//              print("tap cancel") }
-//        }
-        
-        
         .alert(isPresented:$beforeStart) {
             Alert(
                 title: Text("애플워치를 착용하고 있나요?"),
@@ -197,9 +161,9 @@ struct SearchPartnerView: View {
                 }
             )
         }
-        .navigationBarTitle("")        
+        .navigationBarTitle("")
     } // end body
-
+    
 }
 
 

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -181,7 +181,7 @@ struct SearchPartnerView: View {
                 }
             )
         }
-        
+        .navigationBarTitle("")        
     } // end body
 
 }

--- a/BurningBuddy/View/Workout/MissionCongratsComponent.swift
+++ b/BurningBuddy/View/Workout/MissionCongratsComponent.swift
@@ -52,6 +52,7 @@ struct MissionCongratsComponent: View {
         }
         .padding(EdgeInsets(top: 10, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
         .background(Color.backgroundColor)
+        .navigationBarHidden(true)
     }
 }
 

--- a/BurningBuddy/View/Workout/MissionResultModalView.swift
+++ b/BurningBuddy/View/Workout/MissionResultModalView.swift
@@ -61,7 +61,7 @@ struct MissionResultModalView: View {
             }
         }
         .padding(EdgeInsets(top: 10, leading: 30, bottom: 15, trailing: 30))
-        
+        .navigationBarHidden(true)
     }
 }
 

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -78,6 +78,7 @@ struct WorkoutDoneView: View {
                     .background(Color(red: 30/255, green: 28/255, blue: 29/255))
             }
         }
+        .navigationBarHidden(true)
     }
 }
 

--- a/BurningBuddy/View/Workout/WorkoutView.swift
+++ b/BurningBuddy/View/Workout/WorkoutView.swift
@@ -29,13 +29,13 @@ struct WorkoutView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             
             Text("열심히 운동 중!🏃🏻‍♂️")
-                .foregroundColor(.white)
+                .foregroundColor(Color.mainTextColor)
                 .font(.system(size: 28, weight: .bold, design: .default))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
             
             Text("운동이 완료되면\n워치의 운동 기록 측정을 종료하고\n운동 완료하기 버튼을 눌러주세요")
-                .foregroundColor(.white)
+                .foregroundColor(Color.mainTextColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
                 .font(.system(size: 17, weight: .regular, design: .default))
@@ -66,8 +66,10 @@ struct WorkoutView: View {
                 EmptyView()
             }
         }
+        .navigationBarHidden(true)
         .padding(EdgeInsets(top: 10, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
-        .background(Color(red: 30/255, green: 28/255, blue: 29/255)) // 고급진 까만것이 필요할 듯
+        .background(Color.backgroundColor) // 고급진 까만것이 필요할 듯
+        
     }
 }
 


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#35

👷 **작업한 내용**
네비게이션 링크로 다음 단계로 넘어가는 작업을 했습니다.
운동하기 화면에서는 뒤로가기 버튼을 히든하였습니다. 뒤로갈 수 없고 앞으로만 뷰를 전환할 수 있습니다.
또한 파트너 찾기 뷰에서 뒤로가기 버튼을 하얀색 처리 하였습니다.
추후 운동하기 뷰 들은 프레임 미세조정하여 화면 맞출 계획입니다.

## 🚨 참고 사항
Jay가 작업한 파트너뷰의 작업물이 아직 반영이 되지 않았습니다.

## 📸 스크린샷

https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-BurningBuddy/assets/98330884/b0cb4761-f544-49f5-8789-94a83defb151



## 📟 관련 이슈
- 를 깜빡하고 생성하지 않았네요...
