### PR TITLE
[Feat] #36 - 운동 종료 후 NI 재실행, 파트너 목표 달성 여부 확인

### DIFF
--- a/BurningBuddy/Utils/NIUtils/NISessionManager.swift
+++ b/BurningBuddy/Utils/NIUtils/NISessionManager.swift
@@ -183,6 +183,8 @@ class NISessionManager: NSObject, ObservableObject {
                 self.isBumped = true
                 bumpedName = receivedData.nickname
                 bumpedID = receivedData.uuid
+                bumpedIsDoneTargetCalories = receivedData.isDoneTargetCalories
+              // bumpedIsDoneTargetCalories = true
                 DispatchQueue.global(qos: .userInitiated).async {
                     self.shareMyData(token: receivedData.token, peer: peer)
                 }

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -40,17 +40,6 @@ struct SearchPartnerView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Color.mainTextColor)
                     .font(.system(size: 28, weight: .bold, design: .default))
-                switch(niObject.findingPartnerState) {
-                case .ready:
-                    Text("ready")
-                        .foregroundColor(Color.mainTextColor)
-                case .finding:
-                    Text("finding")
-                        .foregroundColor(Color.mainTextColor)
-                case .found:
-                    Text("found")
-                        .foregroundColor(Color.mainTextColor)
-                }
                 Text("서로의 휴대폰을 가까이 붙여주세요")
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundColor(Color.mainTextColor)

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -17,107 +17,124 @@ import SwiftUI
  
  */
 struct WorkoutDoneView: View {
-    @EnvironmentObject var settings: UserSettings
-    @State var isNotDoneWorkoutPopup = false
-    @State private var isSuccessNext: Bool = false
-    @Binding var mainViewNavLinkActive: Bool
-    
-    @StateObject private var niObject = NISessionManager()
-    @State private var isLaunched = true
-    @State var isLocalNetworkPermissionDenied = false
-    @State private var checkPartner: Bool = false
-    @State var isDataReceived: Bool = false
-    private let localNetAuth = LocalNetworkAuthorization()
-    
-    var body: some View {
-        VStack {
-            Text("\(settings.nickName)님")
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundColor(.white)
-                .font(.system(size: 21, weight: .bold))
-            Text("수고하셨어요!")
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundColor(.white)
-                .font(.system(size: 28, weight: .bold))
-            Text("애플워치 운동기록을 종료하신 후\n오늘 함께 운동한 파트너와\n디바이스를 접촉해주세요!")
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
-                .font(.system(size: 17, weight: .regular, design: .default))
-                .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
-            
-            Spacer()
-            ZStack {
-                Image(systemName: "hands.sparkles.fill")
-                    .resizable()
-                    .frame(width: 189, height: 189)
-                    .foregroundColor(Color.bunnyColor)
-            }
-            Spacer()
-            NavigationLink(isActive: $isSuccessNext, destination: {
-                if settings.isDoneTogetherWorkout {
-                    WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
-                } else {
-                    WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
-                }
-                
-            }, label: {
-                Button("목표달성 확인하기") {
-                    print("Navi link 안")
-                    
-                    // TODO: DataReeiveView를 만들어준다 -> 모달 뷰(DataReeiveView) 띄우기 -> 상대방 데이터 통신 -> 모달 뷰 해제
-                    
-                    self.checkPartner = true // 모달뷰 띄우기
-                    if niObject.isBumped {
-                        self.checkPartner = false
-                        if !niObject.isDoneTargetCalories || UserDefaults.standard.bool(forKey: "isDoneWorkout") { // isDoneWorkout: 목표달성 여부 체크 부울값
-                            self.isNotDoneWorkoutPopup = true
-                        } else {
-                            self.isSuccessNext = true
-                        }
-                    }
-                    
-                    
-                    // print("niObject에 저장된 상대방 id", niObject.bumpedID?.uuidString ?? "값 없음")
-                    // print("userDefalut에 저장된 상대방 id", UserDefaults.standard.string(forKey: "partnerID") ?? "값 없음")
-                    // 다음 뷰로 넘어가는 변수
-                }
-                .fullScreenCover(isPresented: self.$checkPartner, content: {
-                    // 상대방이 운동을 달성했는지 확인하는 부분
-                    DataReceiveView(niObject: niObject, isDataReceived: $isSuccessNext, checkPartner: $checkPartner) // TODO: - niObject가 같은 변수를 공유하는지 확인하기 - 잘 돌아간다고 치고
-                        .environmentObject(settings)
-                })
-                
-                .buttonStyle(RedButtonStyle())
-            })
+  @EnvironmentObject var settings: UserSettings
+  @State var isNotDoneWorkoutPopup = false
+  @State private var isSuccessNext: Bool = false
+  @Binding var mainViewNavLinkActive: Bool
+  
+  @StateObject private var niObject = NISessionManager()
+  @State private var isLaunched = true
+  @State var isLocalNetworkPermissionDenied = false
+  @State private var checkPartner: Bool = false
+  @State var isDataReceived: Bool = false
+  private let localNetAuth = LocalNetworkAuthorization()
+  
+  var body: some View {
+      VStack {
+        switch(niObject.findingPartnerState) {
+        case .ready:
+          Text("ready")
+            .foregroundColor(Color.mainTextColor)
+        case .finding:
+          Text("finding")
+            .foregroundColor(Color.mainTextColor)
+        case .found:
+          Text("found")
+            .foregroundColor(Color.mainTextColor)
         }
+        switch(niObject.isBumped) {
+        case true:
+          Text("isBumped: true")
+        case false:
+          Text("isBumped: false")
+        }
+        Text("\(settings.nickName)님")
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .foregroundColor(.white)
+          .font(.system(size: 21, weight: .bold))
+        Text("수고하셨어요!")
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .foregroundColor(.white)
+          .font(.system(size: 28, weight: .bold))
+        Text("애플워치 운동기록을 종료하신 후\n오늘 함께 운동한 파트너와\n디바이스를 접촉해주세요!")
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
+          .font(.system(size: 17, weight: .regular, design: .default))
+          .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
         
-        .padding(EdgeInsets(top: 50, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
-        .background(Color(red: 30/255, green: 28/255, blue: 29/255))
-        .sheet(isPresented: self.$isNotDoneWorkoutPopup) {
-            if #available(iOS 16.0, *) {
-                MissionResultModalView(title: "파트너가 아직 운동 중이에요!", article: "운동을 마칠 때까지 응원해주세요!", leftButtonName: "알겠어요", rightButtonName: "그만할래요", wantQuitWorkout: $isSuccessNext )
-                    .presentationDetents([.fraction(0.4)])
-                    .background(Color(red: 30/255, green: 28/255, blue: 29/255))
-                    .environmentObject(settings)
-                //  TODO: - 수정
-            }
+        Spacer()
+        ZStack {
+          Image(systemName: "hands.sparkles.fill")
+            .resizable()
+            .frame(width: 189, height: 189)
+            .foregroundColor(Color.bunnyColor)
         }
-        .navigationBarHidden(true)
-    }
-    
-    
-    
-    
-    //  private func getDestination() -> some View {
-    //    startNI()
-    //    // peer의 uuid가 저장되어있는 settings.partnerID와 일치하는지 확인
-    //    if settings.isDoneTogetherWorkout {
-    //      return AnyView(WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive))
-    //    }
-    //    else {
-    //      return AnyView(WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive))
-    //    }
-    //  }
+        Spacer()
+        switch(niObject.isBumped) {
+        case true:
+          NavigationLink(isActive: $isSuccessNext, destination: {
+            if settings.isDoneTogetherWorkout {
+              WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
+            } else {
+              WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
+            }
+            
+          }, label: {
+            Button("목표달성 확인하기") {
+              if (niObject.bumpedIsDoneTargetCalories) { // 상대 목표 달성 True
+                isNotDoneWorkoutPopup = false
+              } else {
+                isNotDoneWorkoutPopup = true
+              }
+            }
+            .buttonStyle(RedButtonStyle())
+          })
+        case false:
+          NavigationLink(isActive: $isSuccessNext, destination: {
+            if settings.isDoneTogetherWorkout {
+              WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
+            } else {
+              WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
+            }
+            
+          }, label: {
+            Button("접촉하기") {
+              // NIObject 통신 시작
+              switch niObject.findingPartnerState {
+              case .ready:
+                niObject.start()
+                niObject.findingPartnerState = .finding
+                if isLaunched {
+                  localNetAuth.requestAuthorization { auth in
+                    isLocalNetworkPermissionDenied = !auth
+                  }
+                  isLaunched = false
+                }
+              case .finding:
+                niObject.stop()
+                niObject.findingPartnerState = .ready
+              case .found:
+                niObject.stop()
+                niObject.findingPartnerState = .ready
+              }
+            }
+            .buttonStyle(GrayButtonStyle())
+          })
+        } // switch 끝
+      }
+      
+      .padding(EdgeInsets(top: 50, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
+      .background(Color(red: 30/255, green: 28/255, blue: 29/255))
+      .sheet(isPresented: self.$isNotDoneWorkoutPopup) {
+        if #available(iOS 16.0, *) {
+          MissionResultModalView(title: "파트너가 아직 운동 중이에요!", article: "운동을 마칠 때까지 응원해주세요!", leftButtonName: "알겠어요", rightButtonName: "그만할래요", wantQuitWorkout: $isSuccessNext )
+            .presentationDetents([.fraction(0.4)])
+            .background(Color(red: 30/255, green: 28/255, blue: 29/255))
+            .environmentObject(settings)
+        }
+      }
+      .navigationBarHidden(true)
+  } // body End
 }
 
 //

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -31,23 +31,6 @@ struct WorkoutDoneView: View {
   
   var body: some View {
       VStack {
-        switch(niObject.findingPartnerState) {
-        case .ready:
-          Text("ready")
-            .foregroundColor(Color.mainTextColor)
-        case .finding:
-          Text("finding")
-            .foregroundColor(Color.mainTextColor)
-        case .found:
-          Text("found")
-            .foregroundColor(Color.mainTextColor)
-        }
-        switch(niObject.isBumped) {
-        case true:
-          Text("isBumped: true")
-        case false:
-          Text("isBumped: false")
-        }
         Text("\(settings.nickName)님")
           .frame(maxWidth: .infinity, alignment: .leading)
           .foregroundColor(.white)

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -63,24 +63,34 @@ struct WorkoutDoneView: View {
             }, label: {
                 Button("목표달성 확인하기") {
                     print("Navi link 안")
-                    // 상대방이 운동을 달성했는지 확인하는 부분
-                    // TODO: 새로운 bump View를 만들어준다 -> 
-    
-                    if !niObject.isDoneTargetCalories {
-                        self.isNotDoneWorkoutPopup = true
+                    
+                    // TODO: DataReeiveView를 만들어준다 -> 모달 뷰(DataReeiveView) 띄우기 -> 상대방 데이터 통신 -> 모달 뷰 해제
+                    
+                    self.checkPartner = true // 모달뷰 띄우기
+                    if niObject.isBumped {
+                        self.checkPartner = false
+                        if !niObject.isDoneTargetCalories || UserDefaults.standard.bool(forKey: "isDoneWorkout") { // isDoneWorkout: 목표달성 여부 체크 부울값
+                            self.isNotDoneWorkoutPopup = true
+                        } else {
+                            self.isSuccessNext = true
+                        }
                     }
-                    print("niObject에 저장된 상대방 id", niObject.bumpedID?.uuidString ?? "값 없음")
-                    print("userDefalut에 저장된 상대방 id", UserDefaults.standard.string(forKey: "partnerID") ?? "값 없음")
-                    self.isSuccessNext = true
+                    
+                    
+                    // print("niObject에 저장된 상대방 id", niObject.bumpedID?.uuidString ?? "값 없음")
+                    // print("userDefalut에 저장된 상대방 id", UserDefaults.standard.string(forKey: "partnerID") ?? "값 없음")
+                    // 다음 뷰로 넘어가는 변수
                 }
                 .fullScreenCover(isPresented: self.$checkPartner, content: {
-                    DataReceiveView(isNextButtonTapped: $isDataReceived)
+                    // 상대방이 운동을 달성했는지 확인하는 부분
+                    DataReceiveView(niObject: niObject, isDataReceived: $isSuccessNext, checkPartner: $checkPartner) // TODO: - niObject가 같은 변수를 공유하는지 확인하기 - 잘 돌아간다고 치고
                         .environmentObject(settings)
                 })
+                
                 .buttonStyle(RedButtonStyle())
             })
-            
         }
+        
         .padding(EdgeInsets(top: 50, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
         .background(Color(red: 30/255, green: 28/255, blue: 29/255))
         .sheet(isPresented: self.$isNotDoneWorkoutPopup) {

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -131,6 +131,9 @@ struct WorkoutDoneView: View {
             .presentationDetents([.fraction(0.4)])
             .background(Color(red: 30/255, green: 28/255, blue: 29/255))
             .environmentObject(settings)
+            .onDisappear {
+              niObject.isBumped = false
+            }
         }
       }
       .navigationBarHidden(true)


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#36

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 운동 종료 후 NI를 재실행해 파트너가 목표 칼로리를 달성했는지 확인하고, 달성 여부에 따라 모달 / 내비게이션뷰를 띄웁니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `목표달성 확인하기` 버튼을 두 단계로 나누어 `접촉하기` -> `Bump` -> `목표달성 확인하기` 로 넘어가도록 했습니다.
- 이후 워딩을 수정하거나 로직을 수정해야 할 듯합니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|파트너 목표 달성 여부 확인|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-BurningBuddy/assets/70744494/84a3e3fe-d2fd-4489-a511-b7e3b6bed526" width ="250">|

## 📟 관련 이슈
- Resolved: #36
