### PR TITLE
[Feat] #63 - 운동 종료 후 화면에서 접촉 중인 상태 보여주기

### DIFF
--- a/BurningBuddy.xcodeproj/project.pbxproj
+++ b/BurningBuddy.xcodeproj/project.pbxproj
@@ -518,7 +518,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BurningBuddy\"";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = 82Q43H4UQQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BurningBuddy/Info.plist;
@@ -538,7 +538,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazzi.BurningBuddy;
+				PRODUCT_BUNDLE_IDENTIFIER = com.euipark.BurningBuddy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -555,7 +555,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"BurningBuddy\"";
-				DEVELOPMENT_TEAM = UULN4L9KLP;
+				DEVELOPMENT_TEAM = 82Q43H4UQQ;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BurningBuddy/Info.plist;
@@ -575,7 +575,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazzi.BurningBuddy;
+				PRODUCT_BUNDLE_IDENTIFIER = com.euipark.BurningBuddy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/BurningBuddy/View/Partner/SearchPartnerView.swift
+++ b/BurningBuddy/View/Partner/SearchPartnerView.swift
@@ -76,12 +76,13 @@ struct SearchPartnerView: View {
                         Image(systemName: "person.circle.fill")
                             .resizable()
                             .scaledToFit()
-                            .frame(width: 98, height: 100)
+                            .frame(width: 88)
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(Color.bunnyColorSub, Color.bunnyColor)
-                        Text(niObject.bumpedName)
-                            .font(.system(size: 17, weight: .semibold))
                     }
+                  Text(niObject.bumpedName)
+                      .font(.system(size: 17, weight: .semibold))
+                      .padding(EdgeInsets(top: 120, leading: 0, bottom: 0, trailing: 0))
                 }
                 
             case false:

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -39,7 +39,6 @@ struct WorkoutDoneView: View {
             case .finding, .found:
               LoadingAnimationView()
             case .ready:
-//              Image(systemName: "hands.sparkles.fill")
               Image(systemName: "iphone.gen3.radiowaves.left.and.right")
                 .resizable()
                 .scaledToFit()
@@ -215,12 +214,3 @@ extension WorkoutDoneView {
     }
   }
 }
-//
-//struct WorkoutDoneView_Previews: PreviewProvider {
-//    
-//    static var previews: some View {
-//        WorkoutDoneView()
-//            .environmentObject(UserSettings())
-//    }
-//}
-

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -47,10 +47,15 @@ struct WorkoutDoneView: View {
         
         Spacer()
         ZStack {
-          Image(systemName: "hands.sparkles.fill")
-            .resizable()
-            .frame(width: 189, height: 189)
-            .foregroundColor(Color.bunnyColor)
+          switch(niObject.findingPartnerState) {
+          case .finding, .found:
+            LoadingAnimationView()
+          case .ready:
+            Image(systemName: "hands.sparkles.fill")
+              .resizable()
+              .frame(width: 189, height: 189)
+              .foregroundColor(Color.bunnyColor)
+          }
         }
         Spacer()
         switch(niObject.isBumped) {
@@ -81,7 +86,7 @@ struct WorkoutDoneView: View {
             }
             
           }, label: {
-            Button("접촉하기") {
+            Button("파트너 찾기") {
               // NIObject 통신 시작
               switch niObject.findingPartnerState {
               case .ready:
@@ -101,13 +106,24 @@ struct WorkoutDoneView: View {
                 niObject.findingPartnerState = .ready
               }
             }
-            .buttonStyle(GrayButtonStyle())
+            .buttonStyle(RedButtonStyle())
           })
         } // switch 끝
       }
       
       .padding(EdgeInsets(top: 50, leading: 30, bottom: 15, trailing: 30)) // 전체 아웃라인
       .background(Color(red: 30/255, green: 28/255, blue: 29/255))
+      .sheet(isPresented: self.$isNotDoneWorkoutPopup) {
+        if #available(iOS 16.0, *) {
+          MissionResultModalView(title: "파트너가 아직 운동 중이에요!", article: "운동을 마칠 때까지 응원해주세요!", leftButtonName: "알겠어요", rightButtonName: "그만할래요", wantQuitWorkout: $isSuccessNext )
+            .presentationDetents([.fraction(0.4)])
+            .background(Color(red: 30/255, green: 28/255, blue: 29/255))
+            .environmentObject(settings)
+            .onDisappear {
+              niObject.isBumped = false
+            }
+        }
+      }
       .sheet(isPresented: self.$isNotDoneWorkoutPopup) {
         if #available(iOS 16.0, *) {
           MissionResultModalView(title: "파트너가 아직 운동 중이에요!", article: "운동을 마칠 때까지 응원해주세요!", leftButtonName: "알겠어요", rightButtonName: "그만할래요", wantQuitWorkout: $isSuccessNext )

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -31,20 +31,7 @@ struct WorkoutDoneView: View {
   
   var body: some View {
       VStack {
-        Text("\(settings.nickName)님")
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .foregroundColor(.white)
-          .font(.system(size: 21, weight: .bold))
-        Text("수고하셨어요!")
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .foregroundColor(.white)
-          .font(.system(size: 28, weight: .bold))
-        Text("애플워치 운동기록을 종료하신 후\n오늘 함께 운동한 파트너와\n디바이스를 접촉해주세요!")
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
-          .font(.system(size: 17, weight: .regular, design: .default))
-          .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
-        
+        AnyView(setTitleText()) // 타이틀, 텍스트
         Spacer()
         ZStack {
           switch(niObject.findingPartnerState) {
@@ -78,36 +65,70 @@ struct WorkoutDoneView: View {
             .buttonStyle(RedButtonStyle())
           })
         case false:
-          NavigationLink(isActive: $isSuccessNext, destination: {
-            if settings.isDoneTogetherWorkout {
-              WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
-            } else {
-              WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
-            }
-            
-          }, label: {
-            Button("파트너 찾기") {
-              // NIObject 통신 시작
-              switch niObject.findingPartnerState {
-              case .ready:
-                niObject.start()
-                niObject.findingPartnerState = .finding
-                if isLaunched {
-                  localNetAuth.requestAuthorization { auth in
-                    isLocalNetworkPermissionDenied = !auth
-                  }
-                  isLaunched = false
-                }
-              case .finding:
-                niObject.stop()
-                niObject.findingPartnerState = .ready
-              case .found:
-                niObject.stop()
-                niObject.findingPartnerState = .ready
+          switch (niObject.findingPartnerState) {
+          case .ready:
+            NavigationLink(isActive: $isSuccessNext, destination: {
+              if settings.isDoneTogetherWorkout {
+                WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
+              } else {
+                WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
               }
-            }
-            .buttonStyle(RedButtonStyle())
-          })
+              
+            }, label: {
+              Button("파트너 연결하기") {
+                // NIObject 통신 시작
+                switch niObject.findingPartnerState {
+                case .ready:
+                  niObject.start()
+                  niObject.findingPartnerState = .finding
+                  if isLaunched {
+                    localNetAuth.requestAuthorization { auth in
+                      isLocalNetworkPermissionDenied = !auth
+                    }
+                    isLaunched = false
+                  }
+                case .finding:
+                  niObject.stop()
+                  niObject.findingPartnerState = .ready
+                case .found:
+                  niObject.stop()
+                  niObject.findingPartnerState = .ready
+                }
+              }
+              .buttonStyle(RedButtonStyle())
+            }) // Buggon end
+          case .finding, .found:
+            NavigationLink(isActive: $isSuccessNext, destination: {
+              if settings.isDoneTogetherWorkout {
+                WorkoutSuccessView(mainViewNavLinkActive: $mainViewNavLinkActive)
+              } else {
+                WorkoutFailView(mainViewNavLinkActive: $mainViewNavLinkActive)
+              }
+              
+            }, label: {
+              Button("파트너 연결 취소하기") {
+                // NIObject 통신 시작
+                switch niObject.findingPartnerState {
+                case .ready:
+                  niObject.start()
+                  niObject.findingPartnerState = .finding
+                  if isLaunched {
+                    localNetAuth.requestAuthorization { auth in
+                      isLocalNetworkPermissionDenied = !auth
+                    }
+                    isLaunched = false
+                  }
+                case .finding:
+                  niObject.stop()
+                  niObject.findingPartnerState = .ready
+                case .found:
+                  niObject.stop()
+                  niObject.findingPartnerState = .ready
+                }
+              }
+              .buttonStyle(RedButtonStyle())
+            }) // Buggon end
+          }
         } // switch 끝
       }
       
@@ -124,21 +145,65 @@ struct WorkoutDoneView: View {
             }
         }
       }
-      .sheet(isPresented: self.$isNotDoneWorkoutPopup) {
-        if #available(iOS 16.0, *) {
-          MissionResultModalView(title: "파트너가 아직 운동 중이에요!", article: "운동을 마칠 때까지 응원해주세요!", leftButtonName: "알겠어요", rightButtonName: "그만할래요", wantQuitWorkout: $isSuccessNext )
-            .presentationDetents([.fraction(0.4)])
-            .background(Color(red: 30/255, green: 28/255, blue: 29/255))
-            .environmentObject(settings)
-            .onDisappear {
-              niObject.isBumped = false
-            }
-        }
-      }
       .navigationBarHidden(true)
   } // body End
 }
 
+extension WorkoutDoneView {
+  // 상태에 따라 타이틀과 설명 Text그리는 함수
+  private func setTitleText() -> any View {
+    if !niObject.isBumped {
+      switch(niObject.findingPartnerState) {
+      case .ready:
+        return VStack {
+          Text("\(settings.nickName)님")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.white)
+            .font(.system(size: 21, weight: .bold))
+          Text("수고하셨어요! 🥇")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.white)
+            .font(.system(size: 28, weight: .bold))
+          Text("애플워치 운동기록을 종료하신 후,\n오늘 함께 운동한 파트너와\n목표달성 여부를 공유해보세요")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
+            .font(.system(size: 17, weight: .regular, design: .default))
+            .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
+        }
+      case .finding, .found:
+        return VStack {
+          Text("내 파트너를\n찾는 중이에요")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.white)
+            .font(.system(size: 28, weight: .bold))
+          Text("서로의 휴대폰을 가까이 붙여주세요")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
+            .font(.system(size: 17, weight: .regular, design: .default))
+            .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
+        }
+      }
+    }
+    else {
+      switch(niObject.findingPartnerState) {
+      case .ready:
+        return VStack {
+          Text("파트너와\n연결 완료!")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundColor(.white)
+            .font(.system(size: 28, weight: .bold))
+          Text("파트너와 내가 목표달성에\n성공했는지 확인해보세요!")
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(EdgeInsets(top: 1, leading: 0, bottom: 0, trailing: 0))
+            .font(.system(size: 17, weight: .regular, design: .default))
+            .lineSpacing(TextUtil().calculateLineSpacing(17, 143.5))
+        }
+      default:
+        return Text("케이스 해당 없음")
+      }
+    }
+  }
+}
 //
 //struct WorkoutDoneView_Previews: PreviewProvider {
 //    

--- a/BurningBuddy/View/Workout/WorkoutDoneView.swift
+++ b/BurningBuddy/View/Workout/WorkoutDoneView.swift
@@ -34,13 +34,24 @@ struct WorkoutDoneView: View {
         AnyView(setTitleText()) // 타이틀, 텍스트
         Spacer()
         ZStack {
-          switch(niObject.findingPartnerState) {
-          case .finding, .found:
-            LoadingAnimationView()
-          case .ready:
+          if !niObject.isBumped {
+            switch(niObject.findingPartnerState) {
+            case .finding, .found:
+              LoadingAnimationView()
+            case .ready:
+//              Image(systemName: "hands.sparkles.fill")
+              Image(systemName: "iphone.gen3.radiowaves.left.and.right")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 215)
+                .foregroundColor(Color.bunnyColor)
+            }
+          }
+          else {
             Image(systemName: "hands.sparkles.fill")
               .resizable()
-              .frame(width: 189, height: 189)
+              .scaledToFit()
+              .frame(width: 189)
               .foregroundColor(Color.bunnyColor)
           }
         }


### PR DESCRIPTION
## 🔥 *Pull requests*

⛳️ **작업한 브랜치**
- feature/#63

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 운동종료 후 NI 화면 전면 UI 수정
  사용자가 알아보기 쉽도록 뷰를 세 단계로 나누었습니다.
- SearchPartnerView에서 프로필 레이아웃 안 맞는 부분 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|첫 NI 화면: `SearchPartnerView`|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-BurningBuddy/assets/70744494/66292fc5-4866-4747-93e4-2e1b5a656a33" width ="250">|
|운동 종료 후 NI 화면|<img src = "https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-BurningBuddy/assets/70744494/e96958d6-13e0-4988-be1b-a034d6fbbf0a" width ="250">|



## 📟 관련 이슈
- Resolved: #63
